### PR TITLE
fix(faq): reduce to 3 questions and fix HTML entities

### DIFF
--- a/components/landing/FAQ.tsx
+++ b/components/landing/FAQ.tsx
@@ -1,28 +1,18 @@
 const questions = [
   {
-    question: 'Qu&apos;est-ce que le Fonds Barnier ?',
+    question: "Qu'est-ce que le Fonds Barnier ?",
     answer:
-      'Le Fonds de Prevention des Risques Naturels Majeurs (Fonds Barnier) finance des mesures de prevention et d&apos;indemnisation pour les victimes de catastrophes naturelles, notamment les inondations.',
+      "Le Fonds de Prevention des Risques Naturels Majeurs (Fonds Barnier) finance des mesures de prevention et d'indemnisation pour les victimes de catastrophes naturelles, notamment les inondations.",
   },
   {
     question: 'Suis-je eligible a une indemnisation ?',
     answer:
-      'Vous etes potentiellement eligible si votre commune a fait l&apos;objet d&apos;un arrete de catastrophe naturelle (Cat Nat) et que vous avez subi des dommages lies a l&apos;inondation.',
+      "Vous etes potentiellement eligible si votre commune a fait l'objet d'un arrete de catastrophe naturelle (Cat Nat) et que vous avez subi des dommages lies a l'inondation.",
   },
   {
     question: 'Quels documents dois-je fournir ?',
     answer:
-      'Les documents principaux sont : une piece d&apos;identite, un justificatif de domicile, des photos des dommages, les devis ou factures de reparation, et votre attestation d&apos;assurance habitation.',
-  },
-  {
-    question: 'Combien de temps prend la procedure ?',
-    answer:
-      'Le delai varie selon la complexite du dossier et la reactivite des organismes. En general, comptez entre 2 et 6 mois apres le depot d&apos;un dossier complet.',
-  },
-  {
-    question: 'Le service est-il gratuit ?',
-    answer:
-      'L&apos;utilisation de la plateforme pour constituer et suivre votre dossier est entierement gratuite. Nous sommes la pour simplifier vos demarches.',
+      "Les documents principaux sont : une piece d'identite, un justificatif de domicile, des photos des dommages, les devis ou factures de reparation, et votre attestation d'assurance habitation.",
   },
 ];
 

--- a/components/landing/__tests__/FAQ.test.tsx
+++ b/components/landing/__tests__/FAQ.test.tsx
@@ -8,10 +8,10 @@ describe('FAQ', () => {
     expect(screen.getByText(/questions frequentes/i)).toBeInTheDocument();
   });
 
-  it('affiche 5 questions', () => {
+  it('affiche 3 questions', () => {
     render(<FAQ />);
     const radios = screen.getAllByRole('radio');
-    expect(radios).toHaveLength(5);
+    expect(radios).toHaveLength(3);
   });
 
   it('la premiere question est ouverte par defaut', () => {


### PR DESCRIPTION
## Summary

- Reduit le composant FAQ de 5 a 3 questions comme specifie dans l'issue #9
- Corrige les entites HTML `&apos;` dans les chaines JavaScript qui s'affichaient litteralement au lieu d'etre rendues comme des apostrophes
- Met a jour le test pour valider 3 questions au lieu de 5

Closes #9

## Test plan

- [x] Les 3 tests FAQ passent (`npm test`)
- [x] TypeScript type-check OK (`npm run type-check`)
- [x] ESLint OK (`npm run lint`)
- [x] Prettier OK sur les fichiers modifies
- [ ] Verifier visuellement que les apostrophes s'affichent correctement
- [ ] Verifier le comportement accordion (une seule question ouverte a la fois)
- [ ] Verifier le responsive mobile/desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: SEDIPEC Factory <factory@sedipec.com>