### PR TITLE
feat(landing): add Testimonials section to homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import FAQ from '@/components/landing/FAQ';
 import Hero from '@/components/landing/Hero';
 import HowItWorks from '@/components/landing/HowItWorks';
+import Testimonials from '@/components/landing/Testimonials';
 
 export default function HomePage() {
   return (
@@ -8,6 +9,7 @@ export default function HomePage() {
       <Hero />
       <HowItWorks />
       <FAQ />
+      <Testimonials />
     </main>
   );
 }

--- a/components/landing/Testimonials.tsx
+++ b/components/landing/Testimonials.tsx
@@ -1,0 +1,46 @@
+const testimonials = [
+  {
+    name: 'Marie L.',
+    city: 'Nemours (77)',
+    text: 'Grace a cette plateforme, j&apos;ai pu constituer mon dossier Fonds Barnier en quelques jours seulement. Un vrai gain de temps apres une periode deja difficile.',
+  },
+  {
+    name: 'Jean-Pierre D.',
+    city: 'Lourdes (65)',
+    text: 'Le suivi etape par etape m&apos;a permis de ne rien oublier dans mes demarches. Mon dossier a ete accepte du premier coup.',
+  },
+  {
+    name: 'Sophie M.',
+    city: 'Vaison-la-Romaine (84)',
+    text: 'Apres l&apos;inondation, on ne sait pas par ou commencer. Cette application m&apos;a guidee du debut a la fin. Je recommande vivement.',
+  },
+];
+
+export default function Testimonials() {
+  return (
+    <section className="px-4 py-16 md:py-24">
+      <div className="mx-auto max-w-5xl">
+        <h2 className="mb-12 text-center text-3xl font-bold">
+          Ils nous font confiance
+        </h2>
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          {testimonials.map((testimonial, index) => (
+            <div key={index} className="card card-compact bg-base-100 shadow">
+              <div className="card-body">
+                <p className="text-base-content/70">
+                  &laquo; {testimonial.text} &raquo;
+                </p>
+                <div className="mt-2">
+                  <p className="font-semibold">{testimonial.name}</p>
+                  <p className="text-base-content/50 text-sm">
+                    {testimonial.city}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/__tests__/Testimonials.test.tsx
+++ b/components/landing/__tests__/Testimonials.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Testimonials from '../Testimonials';
+
+describe('Testimonials', () => {
+  it('affiche le titre de la section', () => {
+    render(<Testimonials />);
+    expect(screen.getByText(/ils nous font confiance/i)).toBeInTheDocument();
+  });
+
+  it('affiche 3 temoignages', () => {
+    render(<Testimonials />);
+    expect(screen.getByText('Marie L.')).toBeInTheDocument();
+    expect(screen.getByText('Jean-Pierre D.')).toBeInTheDocument();
+    expect(screen.getByText('Sophie M.')).toBeInTheDocument();
+  });
+
+  it('affiche les villes des temoins', () => {
+    render(<Testimonials />);
+    expect(screen.getByText('Nemours (77)')).toBeInTheDocument();
+    expect(screen.getByText('Lourdes (65)')).toBeInTheDocument();
+    expect(screen.getByText('Vaison-la-Romaine (84)')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Ajout du composant `Testimonials` dans `components/landing/Testimonials.tsx` avec 3 temoignages en dur (nom, ville, texte)
- Design card DaisyUI (card compact, shadow) en grid responsive (1 col mobile, 3 cols desktop)
- Integration dans la page d'accueil (`app/page.tsx`) apres la section FAQ
- Tests unitaires pour le composant

Closes #11

## Test plan

- [ ] Verifier le rendu du titre "Ils nous font confiance"
- [ ] Verifier l'affichage des 3 cartes de temoignages
- [ ] Verifier le responsive : 1 colonne mobile, 3 colonnes desktop
- [ ] `npm test` passe (17/17 tests)
- [ ] `npm run type-check` passe
- [ ] `npm run lint` passe