### PR TITLE
fix(navbar): make navbar responsive with mobile burger menu

### DIFF
--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -14,6 +14,36 @@ export default function Navbar() {
     pathname.startsWith('/admin') || pathname.startsWith('/espace');
   if (hasSidebar) return null;
 
+  const navLinks = (
+    <>
+      <li>
+        <Link href="/about">A propos</Link>
+      </li>
+      {session?.user ? (
+        <li>
+          <Link
+            href={
+              session.user.role === 'admin'
+                ? '/admin/dashboard'
+                : '/espace/mon-dossier'
+            }
+          >
+            Mon espace
+          </Link>
+        </li>
+      ) : (
+        <>
+          <li>
+            <Link href="/auth/login">Connexion</Link>
+          </li>
+          <li>
+            <Link href="/auth/register">Inscription</Link>
+          </li>
+        </>
+      )}
+    </>
+  );
+
   return (
     <nav className="navbar bg-base-100 shadow-sm">
       <div className="flex-1">
@@ -21,34 +51,9 @@ export default function Navbar() {
           FondsBarnierAssistance
         </Link>
       </div>
-      <div className="flex-none gap-2">
-        <ul className="menu menu-horizontal px-1">
-          <li>
-            <Link href="/about">A propos</Link>
-          </li>
-          {session?.user ? (
-            <li>
-              <Link
-                href={
-                  session.user.role === 'admin'
-                    ? '/admin/dashboard'
-                    : '/espace/mon-dossier'
-                }
-              >
-                Mon espace
-              </Link>
-            </li>
-          ) : (
-            <>
-              <li>
-                <Link href="/auth/login">Connexion</Link>
-              </li>
-              <li>
-                <Link href="/auth/register">Inscription</Link>
-              </li>
-            </>
-          )}
-        </ul>
+      {/* Menu desktop */}
+      <div className="hidden gap-2 lg:flex">
+        <ul className="menu menu-horizontal px-1">{navLinks}</ul>
         {session?.user && (
           <>
             <span className="text-base-content/70 text-sm">
@@ -57,6 +62,43 @@ export default function Navbar() {
             <SignOutButton />
           </>
         )}
+      </div>
+      {/* Menu burger mobile */}
+      <div className="flex-none lg:hidden">
+        <div className="dropdown dropdown-end">
+          <div tabIndex={0} role="button" className="btn btn-ghost">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M4 6h16M4 12h16M4 18h7"
+              />
+            </svg>
+          </div>
+          <ul
+            tabIndex={0}
+            className="menu dropdown-content menu-sm rounded-box bg-base-100 z-10 mt-3 w-52 p-2 shadow"
+          >
+            {navLinks}
+            {session?.user && (
+              <>
+                <li className="menu-title">
+                  <span>{session.user.name}</span>
+                </li>
+                <li>
+                  <SignOutButton />
+                </li>
+              </>
+            )}
+          </ul>
+        </div>
       </div>
     </nav>
   );

--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -66,7 +66,7 @@ export default function Navbar() {
       {/* Menu burger mobile */}
       <div className="flex-none lg:hidden">
         <div className="dropdown dropdown-end">
-          <div tabIndex={0} role="button" className="btn btn-ghost">
+          <div tabIndex={0} role="button" aria-label="Menu" className="btn btn-ghost">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               className="h-5 w-5"

--- a/components/shared/__tests__/Navbar.test.tsx
+++ b/components/shared/__tests__/Navbar.test.tsx
@@ -23,8 +23,9 @@ describe('Navbar', () => {
 
   it('contient un lien vers la page A propos', () => {
     render(<Navbar />);
-    const link = screen.getByRole('link', { name: /a propos/i });
-    expect(link).toHaveAttribute('href', '/about');
+    const links = screen.getAllByRole('link', { name: /a propos/i });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    expect(links[0]).toHaveAttribute('href', '/about');
   });
 
   it("contient un lien vers l'accueil", () => {
@@ -37,7 +38,13 @@ describe('Navbar', () => {
 
   it('affiche les liens de connexion et inscription si non connecte', () => {
     render(<Navbar />);
-    expect(screen.getByText('Connexion')).toBeInTheDocument();
-    expect(screen.getByText('Inscription')).toBeInTheDocument();
+    expect(screen.getAllByText('Connexion').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Inscription').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('affiche un bouton burger sur mobile', () => {
+    render(<Navbar />);
+    const burgerButton = screen.getByRole('button');
+    expect(burgerButton).toBeInTheDocument();
   });
 });

--- a/components/shared/__tests__/Navbar.test.tsx
+++ b/components/shared/__tests__/Navbar.test.tsx
@@ -44,7 +44,7 @@ describe('Navbar', () => {
 
   it('affiche un bouton burger sur mobile', () => {
     render(<Navbar />);
-    const burgerButton = screen.getByRole('button');
+    const burgerButton = screen.getByRole('button', { name: /menu/i });
     expect(burgerButton).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Ajout d'un menu burger (dropdown DaisyUI) visible uniquement sur mobile (`lg:hidden`)
- Le menu horizontal desktop est masque sur les petits ecrans (`hidden lg:flex`)
- Les liens de navigation (A propos, Connexion, Inscription, Mon espace) sont accessibles dans les deux menus
- Pour les utilisateurs connectes, le nom et le bouton de deconnexion apparaissent dans le dropdown mobile

Closes #26

## Test plan

- [x] Tests unitaires mis a jour pour gerer les liens dupliques (desktop + mobile)
- [x] Nouveau test pour verifier la presence du bouton burger
- [x] 69 tests passent (12 fichiers)
- [x] TypeScript type-check OK
- [x] ESLint OK
- [ ] Verifier visuellement sur mobile (Safari iOS) que le menu burger fonctionne
- [ ] Verifier que le dropdown se ferme apres un clic sur un lien

Co-Authored-By: SEDIPEC Factory <factory@sedipec.com>