### PR TITLE
fix(auth): move session callback to authConfig for admin redirect

### DIFF
--- a/auth.config.ts
+++ b/auth.config.ts
@@ -51,6 +51,15 @@ export const authConfig = {
 
       return true;
     },
+    // Le callback session doit etre dans authConfig pour que le middleware
+    // puisse acceder au role de l'utilisateur via auth?.user?.role
+    session({ session, token }) {
+      if (token && session.user) {
+        session.user.id = token.id as string;
+        (session.user as { role?: string }).role = token.role as string;
+      }
+      return session;
+    },
   },
   providers: [],
 } satisfies NextAuthConfig;

--- a/auth.ts
+++ b/auth.ts
@@ -79,13 +79,6 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
       return token;
     },
-    async session({ session, token }) {
-      if (token && session.user) {
-        session.user.id = token.id as string;
-        (session.user as { role?: string }).role = token.role as string;
-      }
-      return session;
-    },
     async signIn({ user, account }) {
       // Pour les connexions OAuth, verifier si le compte est actif
       if (account?.provider !== 'credentials') {


### PR DESCRIPTION
## Summary

- Moved the `session` callback from `auth.ts` to `auth.config.ts` so the middleware can access `auth?.user?.role`
- Previously, the role was always `undefined` in the middleware's `authorized` callback, causing admin users to be redirected to `/espace/mon-dossier` instead of `/admin/dashboard`
- The `session` callback in `auth.ts` (via `...authConfig.callbacks` spread) now inherits from `authConfig`, avoiding duplication

## Root cause

The middleware (`middleware.ts`) creates its own NextAuth instance using only `authConfig`. Since the `session` callback that copies `token.role` to `session.user.role` was only defined in `auth.ts`, the middleware never had access to the user's role. All role-based redirects in the `authorized` callback were effectively broken for admins.

## Test plan

- [x] All 69 existing tests pass
- [x] TypeScript type-check passes
- [x] ESLint passes
- [ ] Manual: log in as admin, verify redirect to `/admin/dashboard`
- [ ] Manual: log in as client, verify redirect to `/espace/mon-dossier`
- [ ] Manual: as admin, navigate to `/espace/mon-dossier`, verify redirect to `/admin/dashboard`

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: SEDIPEC Factory <factory@sedipec.com>