### PR TITLE
fix(dossier): modal mobile overflow + source select vide (#36)

### DIFF
--- a/app/admin/dossiers/page.tsx
+++ b/app/admin/dossiers/page.tsx
@@ -37,6 +37,8 @@ export default function AdminDossiersPage() {
   const [displaySearch, setDisplaySearch] = useState('');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [sources, setSources] = useState<Source[]>([]);
+  const [sourcesLoading, setSourcesLoading] = useState(false);
+  const [sourcesError, setSourcesError] = useState('');
   const [createLoading, setCreateLoading] = useState(false);
   const [createError, setCreateError] = useState('');
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -127,18 +129,31 @@ export default function AdminDossiersPage() {
   }
 
   // Charger les sources depuis l'API a l'ouverture du modal
+  const fetchSources = useCallback(async () => {
+    setSourcesLoading(true);
+    setSourcesError('');
+    try {
+      const res = await fetch('/api/v1/sources');
+      const data = await res.json();
+      if (!res.ok) {
+        setSourcesError(data.error || 'Erreur lors du chargement des sources.');
+        return;
+      }
+      if (data.data) setSources(data.data);
+    } catch {
+      setSourcesError(
+        'Impossible de charger les sources. Verifiez votre connexion.',
+      );
+    } finally {
+      setSourcesLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     if (showCreateModal && sources.length === 0) {
-      fetch('/api/v1/sources')
-        .then((res) => res.json())
-        .then((data) => {
-          if (data.data) setSources(data.data);
-        })
-        .catch(() => {
-          // Silencieux — le formulaire affichera une liste vide
-        });
+      fetchSources();
     }
-  }, [showCreateModal, sources.length]);
+  }, [showCreateModal, sources.length, fetchSources]);
 
   return (
     <div className="mx-auto max-w-6xl">
@@ -194,6 +209,9 @@ export default function AdminDossiersPage() {
 
             <DossierForm
               sources={sources}
+              sourcesLoading={sourcesLoading}
+              sourcesError={sourcesError}
+              onRetrySources={fetchSources}
               onSubmit={handleCreateDossier}
               loading={createLoading}
             />

--- a/app/admin/dossiers/page.tsx
+++ b/app/admin/dossiers/page.tsx
@@ -128,30 +128,33 @@ export default function AdminDossiersPage() {
     }
   }
 
-  // Charger les sources depuis l'API a l'ouverture du modal
-  const fetchSources = useCallback(async () => {
+  // Charger les sources depuis l'API à l'ouverture du modal
+  const fetchSources = useCallback(async (signal?: AbortSignal) => {
     setSourcesLoading(true);
     setSourcesError('');
     try {
-      const res = await fetch('/api/v1/sources');
+      const res = await fetch('/api/v1/sources', { signal });
       const data = await res.json();
       if (!res.ok) {
         setSourcesError(data.error || 'Erreur lors du chargement des sources.');
         return;
       }
       if (data.data) setSources(data.data);
-    } catch {
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
       setSourcesError(
         'Impossible de charger les sources. Vérifiez votre connexion.',
       );
     } finally {
-      setSourcesLoading(false);
+      if (!signal?.aborted) setSourcesLoading(false);
     }
   }, []);
 
   useEffect(() => {
     if (showCreateModal && sources.length === 0) {
-      fetchSources();
+      const controller = new AbortController();
+      fetchSources(controller.signal);
+      return () => controller.abort();
     }
   }, [showCreateModal, sources.length, fetchSources]);
 

--- a/app/admin/dossiers/page.tsx
+++ b/app/admin/dossiers/page.tsx
@@ -142,7 +142,7 @@ export default function AdminDossiersPage() {
       if (data.data) setSources(data.data);
     } catch {
       setSourcesError(
-        'Impossible de charger les sources. Verifiez votre connexion.',
+        'Impossible de charger les sources. Vérifiez votre connexion.',
       );
     } finally {
       setSourcesLoading(false);

--- a/app/admin/dossiers/page.tsx
+++ b/app/admin/dossiers/page.tsx
@@ -183,7 +183,7 @@ export default function AdminDossiersPage() {
       {/* Modal nouveau dossier */}
       {showCreateModal && (
         <div className="modal modal-open">
-          <div className="modal-box max-w-2xl">
+          <div className="modal-box max-h-[85vh] max-w-2xl overflow-y-auto [&]:[-webkit-overflow-scrolling:touch]">
             <h3 className="text-lg font-bold">Nouveau dossier</h3>
 
             {createError && (

--- a/components/dossier/DossierForm.tsx
+++ b/components/dossier/DossierForm.tsx
@@ -43,7 +43,7 @@ export default function DossierForm({
     sourceId: dossier?.sourceId ?? sources[0]?.id ?? '',
   });
 
-  // Synchroniser sourceId quand les sources sont chargees apres le montage
+  // Synchroniser sourceId quand les sources sont chargées après le montage
   useEffect(() => {
     if (!dossier && sources.length > 0 && !form.sourceId) {
       setForm((prev) => ({ ...prev, sourceId: sources[0].id }));
@@ -187,7 +187,7 @@ export default function DossierForm({
                   className="btn btn-outline btn-error btn-sm w-fit"
                   onClick={onRetrySources}
                 >
-                  Reessayer
+                  Réessayer
                 </button>
               )}
             </div>

--- a/components/dossier/DossierForm.tsx
+++ b/components/dossier/DossierForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface DossierFormProps {
   dossier?: {
@@ -15,6 +15,9 @@ interface DossierFormProps {
     sourceId?: string;
   };
   sources: { id: string; slug: string; label: string }[];
+  sourcesLoading?: boolean;
+  sourcesError?: string;
+  onRetrySources?: () => void;
   onSubmit: (data: Record<string, string>) => void;
   loading?: boolean;
 }
@@ -22,6 +25,9 @@ interface DossierFormProps {
 export default function DossierForm({
   dossier,
   sources,
+  sourcesLoading = false,
+  sourcesError = '',
+  onRetrySources,
   onSubmit,
   loading = false,
 }: DossierFormProps) {
@@ -36,6 +42,13 @@ export default function DossierForm({
     cadastre: dossier?.cadastre ?? '',
     sourceId: dossier?.sourceId ?? sources[0]?.id ?? '',
   });
+
+  // Synchroniser sourceId quand les sources sont chargees apres le montage
+  useEffect(() => {
+    if (!dossier && sources.length > 0 && !form.sourceId) {
+      setForm((prev) => ({ ...prev, sourceId: sources[0].id }));
+    }
+  }, [sources, dossier, form.sourceId]);
 
   function handleChange(
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
@@ -156,30 +169,49 @@ export default function DossierForm({
       {!dossier && (
         <div className="form-control">
           <label className="label" htmlFor="dossier-source">
-            <span className="label-text">Source</span>
+            <span className="label-text">Source *</span>
           </label>
-          <select
-            id="dossier-source"
-            name="sourceId"
-            className="select select-bordered w-full"
-            value={form.sourceId}
-            onChange={handleChange}
-          >
-            {sources.map((src) => (
-              <option key={src.id} value={src.id}>
-                {src.label}
-              </option>
-            ))}
-          </select>
+          {sourcesLoading ? (
+            <div className="flex items-center gap-2 py-2">
+              <span className="loading loading-spinner loading-sm" />
+              <span className="text-base-content/60 text-sm">
+                Chargement des sources...
+              </span>
+            </div>
+          ) : sourcesError ? (
+            <div className="flex flex-col gap-2">
+              <p className="text-error text-sm">{sourcesError}</p>
+              {onRetrySources && (
+                <button
+                  type="button"
+                  className="btn btn-outline btn-error btn-sm w-fit"
+                  onClick={onRetrySources}
+                >
+                  Reessayer
+                </button>
+              )}
+            </div>
+          ) : (
+            <select
+              id="dossier-source"
+              name="sourceId"
+              className="select select-bordered w-full"
+              value={form.sourceId}
+              onChange={handleChange}
+              required
+            >
+              {sources.map((src) => (
+                <option key={src.id} value={src.id}>
+                  {src.label}
+                </option>
+              ))}
+            </select>
+          )}
         </div>
       )}
 
       <div className="modal-action">
-        <button
-          type="submit"
-          className="btn btn-primary"
-          disabled={loading}
-        >
+        <button type="submit" className="btn btn-primary" disabled={loading}>
           {loading ? (
             <span className="loading loading-spinner loading-sm" />
           ) : dossier ? (

--- a/components/dossier/__tests__/DossierForm.test.tsx
+++ b/components/dossier/__tests__/DossierForm.test.tsx
@@ -1,0 +1,184 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import DossierForm from '../DossierForm';
+
+const mockSources = [
+  { id: 'src-1', slug: 'mairie', label: 'Mairie' },
+  { id: 'src-2', slug: 'web', label: 'Site web' },
+];
+
+describe('DossierForm', () => {
+  const defaultProps = {
+    sources: mockSources,
+    onSubmit: vi.fn(),
+  };
+
+  describe('affichage de base', () => {
+    it('affiche les champs obligatoires', () => {
+      render(<DossierForm {...defaultProps} />);
+      expect(screen.getByLabelText('Nom *')).toBeInTheDocument();
+      expect(screen.getByLabelText('Prenom *')).toBeInTheDocument();
+      expect(screen.getByLabelText('Email *')).toBeInTheDocument();
+    });
+
+    it('affiche le select source avec les options', () => {
+      render(<DossierForm {...defaultProps} />);
+      expect(screen.getByLabelText('Source *')).toBeInTheDocument();
+      expect(screen.getByText('Mairie')).toBeInTheDocument();
+      expect(screen.getByText('Site web')).toBeInTheDocument();
+    });
+
+    it('affiche le bouton "Creer le dossier" en mode creation', () => {
+      render(<DossierForm {...defaultProps} />);
+      expect(
+        screen.getByRole('button', { name: 'Creer le dossier' }),
+      ).toBeInTheDocument();
+    });
+
+    it('affiche le bouton "Enregistrer" en mode edition', () => {
+      render(
+        <DossierForm
+          {...defaultProps}
+          dossier={{ nom: 'Dupont', prenom: 'Jean', email: 'j@d.fr' }}
+        />,
+      );
+      expect(
+        screen.getByRole('button', { name: 'Enregistrer' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('etat loading des sources', () => {
+    it('affiche le spinner quand sourcesLoading est vrai', () => {
+      render(
+        <DossierForm {...defaultProps} sources={[]} sourcesLoading={true} />,
+      );
+      expect(screen.getByText('Chargement des sources...')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Source *')).not.toBeInTheDocument();
+    });
+
+    it('desactive le submit quand loading est vrai', () => {
+      render(<DossierForm {...defaultProps} loading={true} />);
+      expect(screen.getByRole('button', { name: '' })).toBeDisabled();
+    });
+  });
+
+  describe('etat erreur des sources', () => {
+    it('affiche le message d\'erreur quand sourcesError est defini', () => {
+      render(
+        <DossierForm
+          {...defaultProps}
+          sources={[]}
+          sourcesError="Erreur de chargement"
+        />,
+      );
+      expect(screen.getByText('Erreur de chargement')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Source *')).not.toBeInTheDocument();
+    });
+
+    it('affiche le bouton Réessayer quand onRetrySources est fourni', () => {
+      const onRetry = vi.fn();
+      render(
+        <DossierForm
+          {...defaultProps}
+          sources={[]}
+          sourcesError="Erreur"
+          onRetrySources={onRetry}
+        />,
+      );
+      const retryBtn = screen.getByRole('button', { name: 'Réessayer' });
+      expect(retryBtn).toBeInTheDocument();
+    });
+
+    it('appelle onRetrySources au clic sur Réessayer', () => {
+      const onRetry = vi.fn();
+      render(
+        <DossierForm
+          {...defaultProps}
+          sources={[]}
+          sourcesError="Erreur"
+          onRetrySources={onRetry}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Réessayer' }));
+      expect(onRetry).toHaveBeenCalledOnce();
+    });
+
+    it('ne montre pas le bouton Réessayer sans onRetrySources', () => {
+      render(
+        <DossierForm
+          {...defaultProps}
+          sources={[]}
+          sourcesError="Erreur"
+        />,
+      );
+      expect(
+        screen.queryByRole('button', { name: 'Réessayer' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('synchronisation sourceId via useEffect', () => {
+    it('selectionne la premiere source quand les sources arrivent apres le montage', async () => {
+      const { rerender } = render(
+        <DossierForm {...defaultProps} sources={[]} onSubmit={vi.fn()} />,
+      );
+      // Simuler l'arrivee des sources
+      rerender(
+        <DossierForm
+          {...defaultProps}
+          sources={mockSources}
+          onSubmit={vi.fn()}
+        />,
+      );
+      await waitFor(() => {
+        const select = screen.getByLabelText('Source *') as HTMLSelectElement;
+        expect(select.value).toBe('src-1');
+      });
+    });
+
+    it('ne modifie pas sourceId si un dossier est fourni', () => {
+      render(
+        <DossierForm
+          {...defaultProps}
+          dossier={{
+            nom: 'Dupont',
+            prenom: 'Jean',
+            email: 'j@d.fr',
+            sourceId: 'src-2',
+          }}
+        />,
+      );
+      // En mode edition, le select source n'est pas affiche
+      expect(screen.queryByLabelText('Source *')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('soumission du formulaire', () => {
+    it('appelle onSubmit avec les donnees du formulaire', () => {
+      const onSubmit = vi.fn();
+      render(<DossierForm {...defaultProps} onSubmit={onSubmit} />);
+
+      fireEvent.change(screen.getByLabelText('Nom *'), {
+        target: { value: 'Dupont', name: 'nom' },
+      });
+      fireEvent.change(screen.getByLabelText('Prenom *'), {
+        target: { value: 'Jean', name: 'prenom' },
+      });
+      fireEvent.change(screen.getByLabelText('Email *'), {
+        target: { value: 'jean@dupont.fr', name: 'email' },
+      });
+
+      fireEvent.submit(screen.getByRole('button', { name: 'Creer le dossier' }));
+
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nom: 'Dupont',
+          prenom: 'Jean',
+          email: 'jean@dupont.fr',
+          sourceId: 'src-1',
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Modale de creation de dossier: ajout de `max-h-[85vh]` et `overflow-y-auto` pour la rendre scrollable sur mobile iOS Safari
- Select Source: correction du chargement asynchrone — les sources arrivaient apres le montage du formulaire, laissant `sourceId` vide. Ajout d'un `useEffect` de synchronisation
- Remplacement du `catch` silencieux par un spinner de chargement, un message d'erreur explicite, et un bouton "Reessayer"

## Test plan
- [ ] Ouvrir la modale sur iPhone Safari — verifier qu'elle ne deborde pas et qu'on peut scroller
- [ ] Verifier que le select Source affiche les options apres chargement
- [ ] Couper le reseau puis ouvrir la modale — verifier le message d'erreur et le bouton Reessayer
- [ ] Verifier que la modale reste fonctionnelle sur desktop
- [ ] Soumettre un nouveau dossier avec une source selectionnee

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)