### PR TITLE
fix(sources): handle API errors and fix seed early return

### DIFF
--- a/app/admin/dossiers/page.tsx
+++ b/app/admin/dossiers/page.tsx
@@ -134,11 +134,18 @@ export default function AdminDossiersPage() {
     setSourcesError('');
     try {
       const res = await fetch('/api/v1/sources', { signal });
-      const data = await res.json();
       if (!res.ok) {
-        setSourcesError(data.error || 'Erreur lors du chargement des sources.');
+        let errorMsg = 'Erreur lors du chargement des sources.';
+        try {
+          const errBody = await res.json();
+          if (errBody.error) errorMsg = errBody.error;
+        } catch {
+          // Reponse non-JSON, on garde le message par defaut
+        }
+        setSourcesError(errorMsg);
         return;
       }
+      const data = await res.json();
       if (data.data) setSources(data.data);
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;

--- a/app/api/v1/sources/__tests__/route.test.ts
+++ b/app/api/v1/sources/__tests__/route.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mocks
+const mockAuth = vi.fn();
+const mockSelect = vi.fn();
+
+vi.mock('@/utils/serverAuth', () => ({
+  auth: () => mockAuth(),
+}));
+
+vi.mock('@/db', () => {
+  const selectFn = (...args: unknown[]) => mockSelect(...args);
+  return {
+    db: {
+      select: selectFn,
+    },
+  };
+});
+
+vi.mock('@/db/schema', () => ({
+  sources: {
+    id: 'id',
+    slug: 'slug',
+    label: 'label',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  asc: (col: unknown) => col,
+}));
+
+// Import apres les mocks
+import { GET } from '../route';
+
+describe('GET /api/v1/sources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('retourne 401 si non authentifie', async () => {
+    mockAuth.mockResolvedValueOnce(null);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe('Non autorise.');
+  });
+
+  it('retourne la liste des sources', async () => {
+    mockAuth.mockResolvedValueOnce({ user: { id: 'user-1' } });
+
+    const mockData = [
+      { id: '1', slug: 'appel', label: 'Appel telephonique' },
+      { id: '2', slug: 'portail', label: 'Portail client' },
+    ];
+
+    mockSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValueOnce({
+        orderBy: vi.fn().mockResolvedValueOnce(mockData),
+      }),
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual(mockData);
+    expect(body.count).toBe(2);
+  });
+
+  it('retourne 500 si la base de donnees est inaccessible', async () => {
+    mockAuth.mockResolvedValueOnce({ user: { id: 'user-1' } });
+
+    mockSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValueOnce({
+        orderBy: vi.fn().mockRejectedValueOnce(new Error('Connection refused')),
+      }),
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('Erreur lors du chargement des sources.');
+  });
+});

--- a/app/api/v1/sources/route.ts
+++ b/app/api/v1/sources/route.ts
@@ -11,14 +11,21 @@ export async function GET() {
     return NextResponse.json({ error: 'Non autorise.' }, { status: 401 });
   }
 
-  const data = await db
-    .select({
-      id: sources.id,
-      slug: sources.slug,
-      label: sources.label,
-    })
-    .from(sources)
-    .orderBy(asc(sources.label));
+  try {
+    const data = await db
+      .select({
+        id: sources.id,
+        slug: sources.slug,
+        label: sources.label,
+      })
+      .from(sources)
+      .orderBy(asc(sources.label));
 
-  return NextResponse.json({ data });
+    return NextResponse.json({ data, count: data.length });
+  } catch {
+    return NextResponse.json(
+      { error: 'Erreur lors du chargement des sources.' },
+      { status: 500 },
+    );
+  }
 }

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -27,20 +27,18 @@ async function seed() {
 
   if (existingAdmin.length > 0) {
     console.log(`Admin ${adminEmail} existe deja.`);
-    await client.end();
-    return;
+  } else {
+    const hashedPassword = await bcryptjs.hash(adminPassword, 12);
+
+    await db.insert(users).values({
+      name: adminName,
+      email: adminEmail,
+      password: hashedPassword,
+      role: 'admin',
+    });
+
+    console.log(`Admin cree: ${adminEmail}`);
   }
-
-  const hashedPassword = await bcryptjs.hash(adminPassword, 12);
-
-  await db.insert(users).values({
-    name: adminName,
-    email: adminEmail,
-    password: hashedPassword,
-    role: 'admin',
-  });
-
-  console.log(`Admin cree: ${adminEmail}`);
 
   // Seed des sources MVP
   const mvpSources = [
@@ -65,6 +63,7 @@ async function seed() {
   }
 
   await client.end();
+  console.log('Seed termine.');
 }
 
 seed().catch((err) => {


### PR DESCRIPTION
## Summary

Corrige le champ "Source" qui affichait "Impossible de charger les sources. Vérifiez votre connexion." lors de la creation d'un dossier.

**Trois problemes identifies et corriges :**

- **API `/api/v1/sources`** : Aucun try-catch — une erreur DB renvoyait une reponse 500 HTML non-JSON, provoquant l'echec du parsing cote client
- **Client `fetchSources`** : `res.json()` etait appele avant de verifier `res.ok`, donc une reponse 500 non-JSON tombait dans le catch block generique
- **Seed `db/seed.ts`** : Si l'admin existait deja, `return` sortait avant le seeding des sources — les sources n'etaient jamais inserees en base

## Changes

- `app/api/v1/sources/route.ts` : ajout try-catch + champ `count` dans la reponse (convention API)
- `app/admin/dossiers/page.tsx` : verification `res.ok` avant `res.json()` avec fallback gracieux
- `db/seed.ts` : restructuration pour toujours executer le seeding des sources

## Test plan

- [ ] Verifier que le seed insere les sources meme si l'admin existe deja
- [ ] Verifier que le select "Source" charge les options sur la page admin dossiers
- [ ] Verifier qu'une erreur serveur affiche un message d'erreur propre (pas "Verifiez votre connexion")
- [ ] type-check, lint, tests (176/176), build : tous passent

Closes #38

Generated with [Claude Code](https://claude.com/claude-code)